### PR TITLE
Add ability to adjust duration of generated segments

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,7 @@ import VideoUploader from './components/VideoUploader';
 import PromptSelector from './components/PromptSelector'; // Now acts as Timeline View
 import VeoGenerator from './components/VeoGenerator'; // Now acts as Detail View
 import TimelineEditor from './components/TimelineEditor'; // Video editor timeline view
-import { fileToBase64, extractFrameFromVideo, getClosestAspectRatio } from './utils/videoUtils';
+import { fileToBase64, extractFrameFromVideo, getClosestAspectRatio, formatTime } from './utils/videoUtils';
 import { analyzeVideoContent, generateImageAsset, generateVeoAnimation, checkApiKey, promptApiKey } from './services/geminiService';
 import { Zap, AlertTriangle, Key, Film } from 'lucide-react';
 
@@ -241,6 +241,27 @@ const App: React.FC = () => {
     setState(AppState.TIMELINE);
   };
 
+  const handleUpdateSegmentDuration = (segmentId: string, newDuration: number) => {
+    setAnalysis(prev => prev ? ({
+      ...prev,
+      segments: prev.segments.map(s =>
+        s.id === segmentId ? { ...s, duration: newDuration } : s
+      )
+    }) : null);
+  };
+
+  const handleUpdateSegmentTimestamp = (segmentId: string, newTimestamp: number) => {
+    setAnalysis(prev => {
+      if (!prev) return null;
+      const updatedSegments = prev.segments.map(s =>
+        s.id === segmentId ? { ...s, timestamp: newTimestamp, formattedTime: formatTime(newTimestamp) } : s
+      );
+      // Sort segments by timestamp after update
+      updatedSegments.sort((a, b) => a.timestamp - b.timestamp);
+      return { ...prev, segments: updatedSegments };
+    });
+  };
+
   const handleReset = () => {
     if (videoUrl) URL.revokeObjectURL(videoUrl);
     setVideoUrl(null);
@@ -352,6 +373,8 @@ const App: React.FC = () => {
                   analysis={analysis}
                   onBack={handleBackFromEditor}
                   onViewSegment={handleViewSegment}
+                  onUpdateSegmentDuration={handleUpdateSegmentDuration}
+                  onUpdateSegmentTimestamp={handleUpdateSegmentTimestamp}
                />
              </div>
         )}

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -8,6 +8,10 @@ import { formatTime } from "../utils/videoUtils";
 const getAI = () => new GoogleGenAI({ apiKey: process.env.API_KEY });
 
 export const checkApiKey = async (): Promise<boolean> => {
+  // Check for env variable first (local development)
+  if (process.env.API_KEY || process.env.GEMINI_API_KEY) {
+    return true;
+  }
   const win = window as any;
   if (win.aistudio && win.aistudio.hasSelectedApiKey) {
     return await win.aistudio.hasSelectedApiKey();
@@ -16,6 +20,10 @@ export const checkApiKey = async (): Promise<boolean> => {
 };
 
 export const promptApiKey = async (): Promise<boolean> => {
+  // In local dev with env key, nothing to prompt
+  if (process.env.API_KEY || process.env.GEMINI_API_KEY) {
+    return true;
+  }
   const win = window as any;
   if (win.aistudio && win.aistudio.openSelectKey) {
     await win.aistudio.openSelectKey();
@@ -88,11 +96,12 @@ export const analyzeVideoContent = async (videoBase64: string, mimeType: string)
   
   const result = JSON.parse(text) as AnalysisResult;
   
-  // Post-process to add formatted time and default status
+  // Post-process to add formatted time, default status, and default duration
   result.segments = result.segments.map(s => ({
     ...s,
     formattedTime: formatTime(s.timestamp),
-    status: 'idle'
+    status: 'idle',
+    duration: 5 // Default duration of 5 seconds
   }));
 
   return result;

--- a/types.ts
+++ b/types.ts
@@ -11,6 +11,7 @@ export interface Segment {
   imageUrl?: string;
   videoUrl?: string;
   error?: string;
+  duration: number; // Duration of the segment in seconds (default: 5)
 }
 
 export interface AnalysisResult {


### PR DESCRIPTION
## Summary

Adds controls to adjust the duration of individual generated segments in the Timeline Editor, including drag-and-drop functionality to move and resize segments.

## Changes

- Added `duration` field to the `Segment` interface (default: 5 seconds)
- Added +/- duration controls in the Timeline Editor sidebar for each keyframe (1-30 seconds range)
- Added drag-and-drop to move segments on the timeline
- Added left/right resize handles to adjust start time and duration
- Updated timeline visualization to use the segment's actual duration
- Updated active segment detection logic to use segment's duration instead of hardcoded 5 seconds
- Added local dev support for `GEMINI_API_KEY` environment variable

## How to Test

1. Upload a video and let Gemini analyze it
2. Click "Timeline Editor" to open the editor view
3. In the right sidebar (Keyframes section), each segment now has duration controls (+/- buttons)
4. On the Animation track, you can:
   - Drag segments to reposition them on the timeline
   - Drag the left edge to adjust the start time
   - Drag the right edge to adjust the duration
5. Observe that the animation track clips resize accordingly
6. During playback, the active segment detection respects the configured duration

Closes #4

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author